### PR TITLE
Return earlier if the instance has been deleted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ RUN if [ ! -f $CACHITO_ENV_FILE ]; then go mod download ; fi
 # Build manager
 RUN if [ -f $CACHITO_ENV_FILE ] ; then source $CACHITO_ENV_FILE ; fi ; CGO_ENABLED=0  GO111MODULE=on go build ${GO_BUILD_EXTRA_ARGS} -a -o ${DEST_ROOT}/manager main.go
 
-RUN cp -r templates ${DEST_ROOT}/templates
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM $OPERATOR_BASE_IMAGE
@@ -64,9 +62,6 @@ WORKDIR /
 
 # Install operator binary to WORKDIR
 COPY --from=builder ${DEST_ROOT}/manager .
-
-# Install templates
-COPY --from=builder ${DEST_ROOT}/templates ${OPERATOR_TEMPLATES}
 
 USER $USER_ID
 

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -65,7 +65,7 @@ func (r *AnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	//log := r.Log.WithValues("ansibleee", req.NamespacedName)
 
 	instance, err := r.getAnsibleeeInstance(ctx, req)
-	if err != nil {
+	if err != nil || instance.Name == "" {
 		return ctrl.Result{}, err
 	}
 

--- a/example/ansibleee-test.yaml
+++ b/example/ansibleee-test.yaml
@@ -1,7 +1,8 @@
 apiVersion: redhat.com/v1alpha1
 kind: AnsibleEE
 metadata:
-  name: ansibleee-jlarriba
+  name: ansibleee-test
+  namespace: openstack
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute


### PR DESCRIPTION
During the reconciliation loop, if an AnsibleEE instance is delete, the operator keeps trying to recreate it again, failing with several stacktrace in the attempt, which is pretty normal because the instance doesn't exist anymore.
This patch let the reconciliation loop returning earlier and gracefully handling this case.
In addition, the Dockerfile has been updated removing the empty templates/ directory which is not used in this context.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>