### PR TITLE
New custom resource - play

### DIFF
--- a/api/bases/redhat.com_ansibleees.yaml
+++ b/api/bases/redhat.com_ansibleees.yaml
@@ -194,9 +194,8 @@ spec:
                 description: Playbook is the playbook that ansible will run on this
                   execution
                 type: string
-              playbookname:
-                description: PlaybookName is the name for the playbook that ansible
-                  will execute
+              play:
+                description: Play is the playbook contents that ansible will run on execution
                 type: string
               restartPolicy:
                 default: Never

--- a/api/bases/redhat.com_ansibleees.yaml
+++ b/api/bases/redhat.com_ansibleees.yaml
@@ -194,6 +194,10 @@ spec:
                 description: Playbook is the playbook that ansible will run on this
                   execution
                 type: string
+              playbookname:
+                description: PlaybookName is the name for the playbook that ansible
+                  will execute
+                type: string
               restartPolicy:
                 default: Never
                 description: RestartPolicy is the policy applied to the Job on whether

--- a/api/v1alpha1/ansibleee_types.go
+++ b/api/v1alpha1/ansibleee_types.go
@@ -29,6 +29,8 @@ type AnsibleEESpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// PlaybookName is the name for the playbook that ansible will execute
+	PlaybookName string `json:"playbookname,omitempty"`
 	// Playbook is the playbook that ansible will run on this execution
 	Playbook string `json:"playbook,omitempty"`
 	// Image is the container image that will execute the ansible command

--- a/api/v1alpha1/ansibleee_types.go
+++ b/api/v1alpha1/ansibleee_types.go
@@ -29,8 +29,8 @@ type AnsibleEESpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// PlaybookName is the name for the playbook that ansible will execute
-	PlaybookName string `json:"playbookname,omitempty"`
+	// Play is the playbook contents that ansible will run on execution
+	Play string `json:"play,omitempty"`
 	// Playbook is the playbook that ansible will run on this execution
 	Playbook string `json:"playbook,omitempty"`
 	// Image is the container image that will execute the ansible command

--- a/config/crd/bases/redhat.com_ansibleees.yaml
+++ b/config/crd/bases/redhat.com_ansibleees.yaml
@@ -194,9 +194,8 @@ spec:
                 description: Playbook is the playbook that ansible will run on this
                   execution
                 type: string
-              playbookname:
-                description: PlaybookName is the name for the playbook that ansible
-                  will execute
+              play:
+                description: Play is the playbook contents that ansible will run on execution
                 type: string
               restartPolicy:
                 default: Never

--- a/config/crd/bases/redhat.com_ansibleees.yaml
+++ b/config/crd/bases/redhat.com_ansibleees.yaml
@@ -194,6 +194,10 @@ spec:
                 description: Playbook is the playbook that ansible will run on this
                   execution
                 type: string
+              playbookname:
+                description: PlaybookName is the name for the playbook that ansible
+                  will execute
+                type: string
               restartPolicy:
                 default: Never
                 description: RestartPolicy is the policy applied to the Job on whether

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -69,6 +69,50 @@ func (r *AnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	//configMapVars := make(map[string]env.Setter)
+	//r.configMapForAnsibleEE(ctx, instance, helper, &configMapVars)
+
+	if len(instance.Spec.Inventory) > 0 {
+		foundCM := &corev1.ConfigMap{}
+		err = r.Get(ctx, types.NamespacedName{Name: "inventory-configmap", Namespace: instance.Namespace}, foundCM)
+		if err != nil && errors.IsNotFound(err) {
+			// Define a new configmap
+			cm := r.createConfigMapInventory(instance)
+			fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "inventory-configmap")
+			err = r.Create(ctx, cm)
+			if err != nil {
+				fmt.Println(err.Error())
+				return ctrl.Result{}, err
+			}
+			fmt.Println("configmap created successfully - return and requeue")
+			return ctrl.Result{Requeue: true}, nil
+		} else if err != nil {
+			fmt.Println(err.Error())
+			//log.Error(err, "Failed to get Job")
+			return ctrl.Result{}, err
+		}
+	}
+
+	// set configmap for playbook resource
+	if len(instance.Spec.Playbook) > 0 {
+		foundCM := &corev1.ConfigMap{}
+		err = r.Get(ctx, types.NamespacedName{Name: "playbook-configmap", Namespace: instance.Namespace}, foundCM)
+		if err != nil && errors.IsNotFound(err) {
+			cm := r.createConfigMapPlaybook(instance)
+			fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "playbook-configmap")
+			err = r.Create(ctx, cm)
+			if err != nil {
+				fmt.Println(err.Error())
+				return ctrl.Result{}, err
+			}
+			fmt.Println("configmap created successfully - return and requeue")
+			return ctrl.Result{Requeue: true}, nil
+		} else if err != nil {
+			fmt.Println(err.Error())
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Check if the job already exists, if not create a new one
 	foundJob := &batchv1.Job{}
 	err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, foundJob)
@@ -168,6 +212,38 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 	return job, nil
 }
 
+func (r *AnsibleEEReconciler) createConfigMapInventory(instance *redhatcomv1alpha1.AnsibleEE) *corev1.ConfigMap {
+	data := map[string]string{
+		"inventory.yaml": instance.Spec.Inventory,
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inventory-configmap",
+			Namespace: instance.Namespace,
+		},
+		Data: data,
+	}
+
+	return cm
+}
+
+func (r *AnsibleEEReconciler) createConfigMapPlaybook(instance *redhatcomv1alpha1.AnsibleEE) *corev1.ConfigMap {
+	data := map[string]string{
+		"playbook.yaml": instance.Spec.Playbook,
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "playbook-configmap",
+			Namespace: instance.Namespace,
+		},
+		Data: data,
+	}
+
+	return cm
+}
+
 // labelsForAnsibleEE returns the labels for selecting the resources
 // belonging to the given ansibleee CR name.
 func labelsForAnsibleEE(name string) map[string]string {
@@ -177,6 +253,42 @@ func labelsForAnsibleEE(name string) map[string]string {
 func addMounts(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
+
+	if len(instance.Spec.Inventory) > 0 {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "inventory",
+			MountPath: "/runner/inventory/inventory.yaml",
+			SubPath:   "inventory.yaml",
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "inventory",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "inventory-configmap",
+					},
+				},
+			},
+		})
+	}
+
+	if len(instance.Spec.Playbook) > 0 {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "playbook",
+			MountPath: "/runner/projects/playbook.yaml",
+			SubPath:   "playbook.yaml",
+		})
+		volumes = append(volumes, corev1.Volume{
+			Name: "playbook",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "playbook-configmap",
+					},
+				},
+			},
+		})
+	}
 
 	for i := 0; i < len(instance.Spec.Configs); i++ {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -94,24 +94,24 @@ func (r *AnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// set configmap for playbook resource
-	if len(instance.Spec.Playbook) > 0 {
-		foundCM := &corev1.ConfigMap{}
-		err = r.Get(ctx, types.NamespacedName{Name: "playbook-configmap", Namespace: instance.Namespace}, foundCM)
-		if err != nil && errors.IsNotFound(err) {
-			cm := r.createConfigMapPlaybook(instance)
-			fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "playbook-configmap")
-			err = r.Create(ctx, cm)
-			if err != nil {
-				fmt.Println(err.Error())
-				return ctrl.Result{}, err
-			}
-			fmt.Println("configmap created successfully - return and requeue")
-			return ctrl.Result{Requeue: true}, nil
-		} else if err != nil {
-			fmt.Println(err.Error())
-			return ctrl.Result{}, err
-		}
-	}
+	// if len(instance.Spec.Playbook) > 0 {
+	// 	foundCM := &corev1.ConfigMap{}
+	// 	err = r.Get(ctx, types.NamespacedName{Name: "playbook-configmap", Namespace: instance.Namespace}, foundCM)
+	// 	if err != nil && errors.IsNotFound(err) {
+	// 		cm := r.createConfigMapPlaybook(instance)
+	// 		fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "playbook-configmap")
+	// 		err = r.Create(ctx, cm)
+	// 		if err != nil {
+	// 			fmt.Println(err.Error())
+	// 			return ctrl.Result{}, err
+	// 		}
+	// 		fmt.Println("configmap created successfully - return and requeue")
+	// 		return ctrl.Result{Requeue: true}, nil
+	// 	} else if err != nil {
+	// 		fmt.Println(err.Error())
+	// 		return ctrl.Result{}, err
+	// 	}
+	// }
 
 	// Check if the job already exists, if not create a new one
 	foundJob := &batchv1.Job{}

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -171,8 +171,13 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 	if len(args) == 0 {
 		if len(instance.Spec.Playbook) == 0 {
 			args = []string{"ansible-runner", "run", "/runner", "-p", "playbook.yaml"}
+			fmt.Println(instance.Spec.Play)
+			// fmt.Println(";alksdfj;alksdjf")
+			// instance.Spec.Play = "playbook.yaml"
+			// fmt.Println(instance.Spec.Play)
+		} else {
+			args = []string{"ansible-runner", "run", "/runner", "-p", instance.Spec.Playbook}
 		}
-		args = []string{"ansible-runner", "run", "/runner", "-p", instance.Spec.Playbook}
 	}
 
 	job := &batchv1.Job{
@@ -276,7 +281,7 @@ func addMounts(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 	if len(instance.Spec.Play) > 0 {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "playbook",
-			MountPath: "/runner/projects/playbook.yaml",
+			MountPath: "/runner/project/playbook.yaml",
 			SubPath:   "playbook.yaml",
 		})
 		volumes = append(volumes, corev1.Volume{

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -93,25 +93,26 @@ func (r *AnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	// set configmap for playbook resource
-	// if len(instance.Spec.Playbook) > 0 {
-	// 	foundCM := &corev1.ConfigMap{}
-	// 	err = r.Get(ctx, types.NamespacedName{Name: "playbook-configmap", Namespace: instance.Namespace}, foundCM)
-	// 	if err != nil && errors.IsNotFound(err) {
-	// 		cm := r.createConfigMapPlaybook(instance)
-	// 		fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "playbook-configmap")
-	// 		err = r.Create(ctx, cm)
-	// 		if err != nil {
-	// 			fmt.Println(err.Error())
-	// 			return ctrl.Result{}, err
-	// 		}
-	// 		fmt.Println("configmap created successfully - return and requeue")
-	// 		return ctrl.Result{Requeue: true}, nil
-	// 	} else if err != nil {
-	// 		fmt.Println(err.Error())
-	// 		return ctrl.Result{}, err
-	// 	}
-	// }
+	if len(instance.Spec.Play) > 0 {
+		foundCM := &corev1.ConfigMap{}
+		err = r.Get(ctx, types.NamespacedName{Name: "playbook-configmap", Namespace: instance.Namespace}, foundCM)
+		if err != nil && errors.IsNotFound(err) {
+			// Define a new configmap
+			cm := r.createConfigMapPlay(instance)
+			fmt.Printf("Creating a new ConfigMap: ConfigMap.Namespace %s ConfigMap.Name %s\n", cm.Namespace, "playbook-configmap")
+			err = r.Create(ctx, cm)
+			if err != nil {
+				fmt.Println(err.Error())
+				return ctrl.Result{}, err
+			}
+			fmt.Println("configmap created successfully - return and requeue")
+			return ctrl.Result{Requeue: true}, nil
+		} else if err != nil {
+			fmt.Println(err.Error())
+			//log.Error(err, "Failed to get Job")
+			return ctrl.Result{}, err
+		}
+	}
 
 	// Check if the job already exists, if not create a new one
 	foundJob := &batchv1.Job{}
@@ -169,7 +170,7 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 
 	if len(args) == 0 {
 		if len(instance.Spec.Playbook) == 0 {
-			instance.Spec.Playbook = "standalone-playbook.yaml"
+			args = []string{"ansible-runner", "run", "/runner", "-p", "playbook.yaml"}
 		}
 		args = []string{"ansible-runner", "run", "/runner", "-p", instance.Spec.Playbook}
 	}
@@ -228,9 +229,9 @@ func (r *AnsibleEEReconciler) createConfigMapInventory(instance *redhatcomv1alph
 	return cm
 }
 
-func (r *AnsibleEEReconciler) createConfigMapPlaybook(instance *redhatcomv1alpha1.AnsibleEE) *corev1.ConfigMap {
+func (r *AnsibleEEReconciler) createConfigMapPlay(instance *redhatcomv1alpha1.AnsibleEE) *corev1.ConfigMap {
 	data := map[string]string{
-		"playbook.yaml": instance.Spec.Playbook,
+		"playbook.yaml": instance.Spec.Play,
 	}
 
 	cm := &corev1.ConfigMap{
@@ -272,7 +273,7 @@ func addMounts(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 		})
 	}
 
-	if len(instance.Spec.Playbook) > 0 {
+	if len(instance.Spec.Play) > 0 {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "playbook",
 			MountPath: "/runner/projects/playbook.yaml",

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -68,7 +68,7 @@ func (r *AnsibleEEReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil || instance.Name == "" {
 		return ctrl.Result{}, err
 	}
-  
+
 	// Check if the job already exists, if not create a new one
 	foundJob := &batchv1.Job{}
 	err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, foundJob)
@@ -127,12 +127,11 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 		if len(instance.Spec.Playbook) == 0 {
 			if len(instance.Spec.Play) > 0 {
 				instance.Spec.Playbook = "playbook.yaml"
-				fmt.Println(instance.Spec.Play)
 			} else {
 				instance.Spec.Playbook = "standalone-playbook.yaml"
 			}
-
 		}
+		args = []string{"ansible-runner", "run", "/runner", "-p", instance.Spec.Playbook}
 	}
 
 	job := &batchv1.Job{
@@ -161,7 +160,7 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 	}
 
 	addInventory(instance, job)
-  	addPlay(instance, job)
+	addPlay(instance, job)
 	addRoles(instance, job)
 	addMounts(instance, job)
 
@@ -173,6 +172,7 @@ func (r *AnsibleEEReconciler) jobForAnsibleEE(instance *redhatcomv1alpha1.Ansibl
 
 	return job, nil
 }
+
 // labelsForAnsibleEE returns the labels for selecting the resources
 // belonging to the given ansibleee CR name.
 func labelsForAnsibleEE(name string) map[string]string {
@@ -182,7 +182,7 @@ func labelsForAnsibleEE(name string) map[string]string {
 func addMounts(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
-  
+
 	for i := 0; i < len(instance.Spec.Configs); i++ {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      instance.Spec.Configs[i].Name,
@@ -223,7 +223,7 @@ func addPlay(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 	playEnvVar.Name = "RUNNER_PLAYBOOK"
 	playEnvVar.Value = "\n" + instance.Spec.Play + "\n\n"
 	instance.Spec.Env = append(instance.Spec.Env, playEnvVar)
-  job.Spec.Template.Spec.Containers[0].Env = instance.Spec.Env
+	job.Spec.Template.Spec.Containers[0].Env = instance.Spec.Env
 }
 
 func addInventory(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {

--- a/examples/ansibleee-play.yaml
+++ b/examples/ansibleee-play.yaml
@@ -1,15 +1,18 @@
 apiVersion: redhat.com/v1alpha1
 kind: AnsibleEE
 metadata:
-  name: ansibleee-playbook-local
+  name: ansibleee-play
   namespace: openstack
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
   play: |
-    name: Execute hello world
-    debug:
-      msg: Hello, world!
+    - name: Print hello world
+      hosts: all
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world this is ansibleee-play.yaml"
   # playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
   image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"

--- a/examples/ansibleee-playbook-local.yaml
+++ b/examples/ansibleee-playbook-local.yaml
@@ -7,9 +7,12 @@ spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
   play: |
-    name: Execute hello world
-    debug:
-      msg: Hello, world!
+    - name: Print hello world
+      hosts: all
+      tasks:
+      - name: Using debug statement
+        ansible.builtin.debug:
+          msg: "Hello, world!"
   # playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
   image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"

--- a/examples/ansibleee-playbook-local.yaml
+++ b/examples/ansibleee-playbook-local.yaml
@@ -6,14 +6,14 @@ metadata:
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
-  play: |
-    - name: Print hello world
-      hosts: all
-      tasks:
-      - name: Using debug statement
-        ansible.builtin.debug:
-          msg: "Hello, world!"
-  # playbook: "test.yaml"
+  # play: |
+  #   - name: Print hello world
+  #     hosts: all
+  #     tasks:
+  #     - name: Using debug statement
+  #       ansible.builtin.debug:
+  #         msg: "Hello, world!"
+  playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
   image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"
   inventory: |

--- a/examples/ansibleee-playbook-local.yaml
+++ b/examples/ansibleee-playbook-local.yaml
@@ -3,13 +3,14 @@ kind: AnsibleEE
 metadata:
   name: ansibleee-playbook-local
   namespace: openstack
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"hello": "world"}
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
-  playbook: "test.yaml"
+  play: |
+    name: Execute hello world
+    debug:
+      msg: Hello, world!
+  # playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
   image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"
   inventory: |

--- a/examples/ansibleee-playbook-local.yaml
+++ b/examples/ansibleee-playbook-local.yaml
@@ -3,6 +3,9 @@ kind: AnsibleEE
 metadata:
   name: ansibleee-playbook-local
   namespace: openstack
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"hello": "world"}
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute

--- a/examples/ansibleee-playbook.yaml
+++ b/examples/ansibleee-playbook.yaml
@@ -7,6 +7,7 @@ spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
   playbook: "deploy-tripleo-os-configure.yml"
+  # play: |
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
   image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"
   inventory: |


### PR DESCRIPTION
A few things, Could the validation error for status.nodes be related to the cluster age? I ran `oc get config` with the following output:
```
NAME      AGE
cluster   134d
```

Ran `$ ./bin/manager` - initial state was fine, but once I created ansibleee-test.yml this error came up again. Also, looks like playbook-config map is successfully created. Not sure if I need to introduce creating another job in the reconcile function. 
```
I1117 18:46:55.210702 2412650 request.go:682] Waited for 1.043355068s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/operators.coreos.com/v1alpha1?timeout=32s
1.668707216417091e+09   INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
1.6687072164181502e+09  INFO    setup   starting manager
1.6687072164186494e+09  INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
1.6687072164187126e+09  INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
1.6687072164190018e+09  INFO    Starting EventSource    {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE", "source": "kind source: *v1alpha1.AnsibleEE"}
1.6687072164191613e+09  INFO    Starting EventSource    {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE", "source": "kind source: *v1.Job"}
1.668707216419192e+09   INFO    Starting EventSource    {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE", "source": "kind source: *v1.ConfigMap"}
1.6687072164192145e+09  INFO    Starting Controller     {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE"}
1.6687072167234418e+09  INFO    Starting workers        {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE", "worker count": 1}
Creating a new ConfigMap: ConfigMap.Namespace openstack ConfigMap.Name playbook-configmap
configmap created successfully - return and requeue
Creating a new Job: Job.Namespace openstack Job.Name ansibleee-test
jobs.batch "ansibleee-test" already exists
1.6687073157908645e+09  ERROR   Reconciler error        {"controller": "ansibleee", "controllerGroup": "redhat.com", "controllerKind": "AnsibleEE", "AnsibleEE": {"name":"ansibleee-test","namespace":"openstack"}, "namespace": "openstack", "name": "ansibleee-test", "reconcileID": "4eaf9ee5-1b40-4031-930a-11575ee1ae26", "error": "jobs.batch \"ansibleee-test\" already exists"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/adrbrown/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:326
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/adrbrown/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/adrbrown/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234
```