### PR TITLE
dev: moved image back to triple-ansibleee

### DIFF
--- a/examples/ansibleee-play.yaml
+++ b/examples/ansibleee-play.yaml
@@ -15,7 +15,7 @@ spec:
           msg: "Hello, world this is ansibleee-play.yaml"
   # playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
-  image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"
+  image: "quay.io/jlarriba/openstack-tripleo-ansible-ee:stable"
   inventory: |
     all:
       hosts:

--- a/examples/ansibleee-play.yaml
+++ b/examples/ansibleee-play.yaml
@@ -15,7 +15,7 @@ spec:
           msg: "Hello, world this is ansibleee-play.yaml"
   # playbook: "test.yaml"
   # args: ["ansible-runner", "run", "/runner", "-vvv", "-p", "test.yaml"]
-  image: "quay.io/adrbrown/osp-ansible-runner"
+  image: "quay.io/jlarriba/openstack-tripleo-ansible-ee"
   inventory: |
     all:
       hosts:


### PR DESCRIPTION
@fultonj moved image back over to tripleo-ansibleee, looks like its an issue with my local image. Our example crd should use the tripleo-ansibleee base image anyways. Thanks for catching this!