### PR TITLE
Support SubPath on VolumeMounts

### DIFF
--- a/api/bases/redhat.com_ansibleees.yaml
+++ b/api/bases/redhat.com_ansibleees.yaml
@@ -61,6 +61,10 @@ spec:
                       description: Name is the name of the ConfigMap that we want
                         to mount
                       type: string
+                    subpath:
+                      description: SubPath is the path from the ConfigMap to mount
+                        at MountPoint
+                      type: string
                   required:
                   - mountpath
                   - name

--- a/api/v1alpha1/ansibleee_types.go
+++ b/api/v1alpha1/ansibleee_types.go
@@ -101,6 +101,8 @@ type Config struct {
 	Name string `json:"name"`
 	// MountPoint is the directory of the container where the ConfigMap will be mounted
 	MountPath string `json:"mountpath"`
+	// SubPath is the path from the ConfigMap to mount at MountPoint
+	SubPath string `json:"subpath,omitempty"`
 }
 
 // Role describes the format of an ansible playbook destinated to run roles
@@ -114,20 +116,20 @@ type Role struct {
 	// +kubebuilder:default:=true
 	AnyErrorsFatal bool `json:"any_errors_fatal,omitempty" yaml:"any_errors_fatal,omitempty"`
 	// +kubebuilder:default:=true
-	Become bool `json:"become,omitempty"`
-	Tasks []Task `json:"tasks"`
+	Become bool   `json:"become,omitempty"`
+	Tasks  []Task `json:"tasks"`
 }
 
 // Task describes a task centered exclusively in running import_role
 type Task struct {
-	Name string `json:"name"`
+	Name       string     `json:"name"`
 	ImportRole ImportRole `json:"import_role" yaml:"import_role"`
-	Tags []string `json:"tags,omitempty"`
+	Tags       []string   `json:"tags,omitempty"`
 }
 
 // ImportRole contains the actual rolename and tasks file name to execute
 type ImportRole struct {
-	Name string `json:"name"`
+	Name      string `json:"name"`
 	TasksFrom string `json:"tasks_from" yaml:"tasks_from"`
 }
 

--- a/config/crd/bases/redhat.com_ansibleees.yaml
+++ b/config/crd/bases/redhat.com_ansibleees.yaml
@@ -61,6 +61,10 @@ spec:
                       description: Name is the name of the ConfigMap that we want
                         to mount
                       type: string
+                    subpath:
+                      description: SubPath is the path from the ConfigMap to mount
+                        at MountPoint
+                      type: string
                   required:
                   - mountpath
                   - name

--- a/controllers/ansibleee_controller.go
+++ b/controllers/ansibleee_controller.go
@@ -186,6 +186,7 @@ func addMounts(instance *redhatcomv1alpha1.AnsibleEE, job *batchv1.Job) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      instance.Spec.Configs[i].Name,
 			MountPath: instance.Spec.Configs[i].MountPath,
+			SubPath:   instance.Spec.Configs[i].SubPath,
 		})
 		volumes = append(volumes, corev1.Volume{
 			Name: instance.Spec.Configs[i].Name,


### PR DESCRIPTION
Allows for mounting a specific file from a ConfigMap, instead of the
whole ConfigMap as a directory. Needed so just the ssh key can be
mounted at /runner/env/ssh_key.
