### PR TITLE
Override maxDescLen for install and deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
@@ -133,6 +133,7 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
+install: CRDDESC_OVERRIDE=:maxDescLen=0
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
@@ -141,6 +142,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
+deploy: CRDDESC_OVERRIDE=:maxDescLen=0
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -


### PR DESCRIPTION
Installing CRDs might fail due to the length of the CRD. This patch aligns the ansible operator to the cinder and glance PRs [1][2], where the descriptions on the CRDs are removed when install and deploy targets are run. For instance, the patch [3], which introduces extraVolumes to glance-operator requires this fix, otherwise we'll fail with the following:

"invalid: metadata.annotations: Too long: must have at most 262144 bytes"

[1] openstack-k8s-operators/cinder-operator#81
[2] openstack-k8s-operators/glance-operator#94
[3] openstack-k8s-operators/glance-operator#75

Signed-off-by: Francesco Pantano <fpantano@redhat.com>