### PR TITLE
Support OwnNamespace installMode

### DIFF
--- a/config/manifests/bases/ansibleee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ansibleee-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
Set supported:true for the OwnNamespace installMode. This change matches
the other operators from openstack-k8s-operators and allows the
ansibleee-operator to function within the openstack operator group.

Signed-off-by: James Slagle <jslagle@redhat.com>
