### PR TITLE
Update actions/checkout and actions/setup-go to v3

### DIFF
--- a/.github/workflows/build-ansibleee-operator.yaml
+++ b/.github/workflows/build-ansibleee-operator.yaml
@@ -43,7 +43,7 @@ jobs:
     if: needs.check-secrets.outputs.have-secrets == 'true'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
@@ -80,12 +80,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.18.x
 
     - name: Checkout ansibleee-operator repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install operator-sdk
       uses: redhat-actions/openshift-tools-installer@v1
@@ -153,7 +153,7 @@ jobs:
 
     steps:
     - name: Checkout ansibleee-operator repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout project code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Checkout openstack-k8s-operators-ci project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openstack-k8s-operators/openstack-k8s-operators-ci
           path: ./openstack-k8s-operators-ci
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
       - name: Checkout project code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/release-ansibleee-operator.yaml
+++ b/.github/workflows/release-ansibleee-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Tag image
       uses: tinact/docker.image-retag@1.0.2


### PR DESCRIPTION
It will fix the github actions Annotations warning coming here: https://github.com/openstack-k8s-operators/ansibleee-operator/actions/runs/3647655700

Signed-off-by: Chandan Kumar (raukadah) <raukadah@gmail.com>