### PR TITLE
Adding mkdocs and automate CR fields documentation

### DIFF
--- a/.github/workflows/docs
+++ b/.github/workflows/docs
@@ -1,0 +1,23 @@
+name: Build Docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # this fetches all branches. Needed because we need gh-pages branch for deploy to work
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install MkDocs
+        run: pip install -r docs/doc_requirements.txt
+      - name: Publish docs
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          mkdocs gh-deploy --force --clean --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ CI_TOOLS_REPO
 # generated workspace file
 go.work
 go.work.sum
+
+# docs
+site/

--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,10 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen crd-to-markdown ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd$(CRDDESC_OVERRIDE) webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
 	rm -f api/bases/* && cp -a config/crd/bases api/
+	$(CRD_MARKDOWN) -f api/v1alpha1/ansibleee_types.go -n AnsibleEE > docs/ansibleee.md
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -164,10 +165,12 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+CRD_MARKDOWN ?= $(LOCALBIN)/crd-to-markdown
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.2
+CRD_MARKDOWN_VERSION ?= v0.0.3
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -180,6 +183,11 @@ $(KUSTOMIZE): $(LOCALBIN)
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: crd-to-markdown
+crd-to-markdown: $(CRD_MARKDOWN) ## Download crd-to-markdown locally if necessary.
+$(CRD_MARKDOWN): $(LOCALBIN)
+	test -s $(LOCALBIN)/crd-to-markdown || GOBIN=$(LOCALBIN) go install github.com/clamoriniere/crd-to-markdown@$(CRD_MARKDOWN_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/docs/ansibleee.md
+++ b/docs/ansibleee.md
@@ -1,0 +1,118 @@
+
+### Custom Resources
+
+* [AnsibleEE](#ansibleee)
+
+### Sub Resources
+
+* [AnsibleEEList](#ansibleeelist)
+* [AnsibleEESpec](#ansibleeespec)
+* [AnsibleEEStatus](#ansibleeestatus)
+* [Config](#config)
+* [ImportRole](#importrole)
+* [Role](#role)
+* [Task](#task)
+
+#### AnsibleEE
+
+AnsibleEE is the Schema for the ansibleees API
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | metav1.ObjectMeta | false |
+| spec |  | [AnsibleEESpec](#ansibleeespec) | false |
+| status |  | [AnsibleEEStatus](#ansibleeestatus) | false |
+
+[Back to Custom Resources](#custom-resources)
+
+#### AnsibleEEList
+
+AnsibleEEList contains a list of AnsibleEE
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| metadata |  | metav1.ListMeta | false |
+| items |  | [][AnsibleEE](#ansibleee) | true |
+
+[Back to Custom Resources](#custom-resources)
+
+#### AnsibleEESpec
+
+AnsibleEESpec defines the desired state of AnsibleEE
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| play | Play is the playbook contents that ansible will run on execution. If both Play and Roles are specified, Play takes precedence | string | false |
+| playbook | Playbook is the playbook that ansible will run on this execution | string | false |
+| image | Image is the container image that will execute the ansible command | string | false |
+| args | Args are the command plus the playbook executed by the image. If args is passed, Playbook is ignored. | []string | false |
+| name | Name is the name of the internal container inside the pod | string | false |
+| env | Env is a list containing the environment variables to pass to the pod | []corev1.EnvVar | false |
+| restartPolicy | RestartPolicy is the policy applied to the Job on whether it needs to restart the Pod. It can be \"OnFailure\" or \"Never\". | string | false |
+| uid | UID is the userid that will be used to run the container. | int64 | false |
+| inventory | Inventory is the inventory that the ansible playbook will use to launch the job. | string | false |
+| extraMounts | ExtraMounts containing conf files and credentials | []storage.VolMounts | true |
+| backoffLimit | BackoffLimimt allows to define the maximum number of retried executions. | *int32 | false |
+| ttlSecondsAfterFinished | TTLSecondsAfterFinished specified the number of seconds the job will be kept in Kubernetes after completion. | *int32 | false |
+| roles | Role is the description of an Ansible Role If both Play and Role are specified, Play takes precedence | [Role](#role) | false |
+
+[Back to Custom Resources](#custom-resources)
+
+#### AnsibleEEStatus
+
+AnsibleEEStatus defines the observed state of AnsibleEE
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| nodes | Nodes are the names of the ansibleee pods | []string | true |
+
+[Back to Custom Resources](#custom-resources)
+
+#### Config
+
+Config is a specification of where to mount a certain ConfigMap object
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| name | Name is the name of the ConfigMap that we want to mount | string | true |
+| mountpath | MountPoint is the directory of the container where the ConfigMap will be mounted | string | true |
+
+[Back to Custom Resources](#custom-resources)
+
+#### ImportRole
+
+ImportRole contains the actual rolename and tasks file name to execute
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| name |  | string | true |
+| tasks_from |  | string | true |
+
+[Back to Custom Resources](#custom-resources)
+
+#### Role
+
+Role describes the format of an ansible playbook destinated to run roles
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| name |  | string | false |
+| hosts |  | string | false |
+| strategy |  | string | false |
+| any_errors_fatal |  | bool | false |
+| become |  | bool | false |
+| tasks |  | [][Task](#task) | true |
+
+[Back to Custom Resources](#custom-resources)
+
+#### Task
+
+Task describes a task centered exclusively in running import_role
+
+| Field | Description | Scheme | Required |
+| ----- | ----------- | ------ | -------- |
+| name |  | string | true |
+| import_role |  | [ImportRole](#importrole) | true |
+| tags |  | []string | false |
+
+[Back to Custom Resources](#custom-resources)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,25 @@
+Contributing
+============
+
+Testing
+-------
+
+The tests can be run with the following command:
+```bash
+make test
+```
+
+Docs Testing
+------------
+
+Cross-platform:
+```
+pip install -r docs/doc_requirements.txt
+```
+
+Then:
+```
+mkdocs serve
+```
+Click the link it outputs. As you save changes to files modified in your editor,
+the browser will automatically show the new content.

--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -1,0 +1,4 @@
+mkdocs
+mike
+mkdocs-git-revision-date-plugin
+mkdocs-material

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,44 @@
+site_name: Ansible EE Operator
+site_description: Ansible EE Operator
+site_author: Ansible EE Team
+site_url: https://openstack-k8s-operators.github.io/ansibleee-operator
+repo_name: openstack-k8s-operators/ansibleee-operator
+repo_url: https://github.com/openstack-k8s-operators/ansibleee-operator
+theme:
+  features:
+    - search.suggest
+    - search.highlight
+    - search.share
+  name: material
+  palette:
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: white
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: white
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
+nav:
+  - Home: index.md
+  - Custom Resources:
+      - AnsibleEE: ansibleee.md
+  - Contributing: contributing.md
+markdown_extensions:
+  - toc:
+      permalink: "#"
+  - pymdownx.superfences
+  - admonition
+extra:
+  version:
+    provider: mike
+    default: latest
+plugins:
+  - git-revision-date
+  - search:
+      lang: en
+      prebuild_index: true


### PR DESCRIPTION
It will document all the fields from `AnsibleEE` CR like this:
https://docs.pulpproject.org/pulp_operator/pulp/

You can check out this PR locally and follow these steps: https://docs.pulpproject.org/pulp_operator/contributing/#docs-testing
for building and visualizing the docs